### PR TITLE
Updated the context menu.  A user can not like, dislike or report the…

### DIFF
--- a/client/src/data/UserStore.js
+++ b/client/src/data/UserStore.js
@@ -37,18 +37,28 @@ const initialState = {
 
 function reducer(state, action) {
   switch (action.type) {
-    case 'editPost':
-      return { ...state, postFormOpen: true, activeForm: action.payload };
+    case 'likeComment':
+      console.log(`liked commentId: ${action.payload}`);
+      return { ...state };
+    case 'dislikeComment':
+      console.log(`disliked commentId: ${action.payload}`);
+      return { ...state };
     case 'addCommentToPost':
+      return { ...state, commentFormOpen: true, activeForm: action.payload };
+    case 'editComment':
       return { ...state, commentFormOpen: true, activeForm: action.payload };
     case 'CommentFormSave':
       // Prints to the console, the submitted post data.
       console.log(action.payload);
-    return { ...state };
+      return { ...state };
+    case 'reportComment':
+      console.log(`commentId ${action.payload} has been reported`);
+      return { ...state };
     case 'CommentFormClose':
       // Prints to the console, the submitted post data.
       return { ...state, commentFormOpen: false, activeForm: null };
-    return { ...state };
+    case 'editPost':
+      return { ...state, postFormOpen: true, activeForm: action.payload };
     case 'PostFormSave':
       // Prints to the console, the submitted post data.
       console.log(action.payload);

--- a/client/src/views/ContextActions.js
+++ b/client/src/views/ContextActions.js
@@ -41,10 +41,42 @@ export const ContextActionsDrawer = (props) => {
     setState({ ...state, [side]: open });
   };
 
-
-  const matches = (props) => {
-    
+  const canComment = () => {
+    let allowComment = false;
+    if (props.post) {
+      // We current only support comments on posts.
+      allowComment = true; 
+    }
+    return allowComment;
   }
+
+  // Show the edit post option when the context menu is attached to
+  // a post and the user is the author.
+  const canEditComment = () => {
+    return isAuthor() && props.comment;
+  }
+
+  // Show the edit post option when the context menu is attached to
+  // a post and the user is the author.
+  const canEditPost = () => {
+    return isAuthor() && props.post;
+  }
+
+  // Checks if the current user is the owner of the post or comment.
+  const isAuthor = () => {
+    let author = false;
+
+    if (props.post && props.userId == props.post.author.id) {
+      author = true;
+    }
+
+    if (props.comment && props.userId == props.comment.author.id) {
+      author = true;
+    }
+
+    return author;
+  }
+
 
   const fullList = side => (
     <div
@@ -54,46 +86,67 @@ export const ContextActionsDrawer = (props) => {
       onKeyDown={toggleDrawer(side, false)}
     >
       <List>
-        <ListItem button>
-          <ListItemIcon>
-            <EditIcon />
-          </ListItemIcon>
-          <ListItemText primary="Edit Post" />
-        </ListItem>
-        <ListItem button onClick={() => props.onLike(props.id)}>
-          <ListItemIcon>
-            <ThumbUpIcon />
-          </ListItemIcon>
-          <ListItemText primary="Like" />
-        </ListItem>
-        <ListItem button onClick={() => props.onDislike(props.id)}>
-          <ListItemIcon>
-            <ThumbDownIcon />
-          </ListItemIcon>
-          <ListItemText primary="Dislike" />
-        </ListItem>
-        <ListItem button onClick={() => props.onAddComment(props.id)}>
-          <ListItemIcon>
-            <AddCommentIcon />
-          </ListItemIcon>
-          <ListItemText primary="Add Comment" />
-        </ListItem>
-        <ListItem button onClick={() => props.onFriendRequest(props.author)}>
-          <ListItemIcon>
-            <PersonAddIcon />
-          </ListItemIcon>
-          <ListItemText primary="Friend Request" />
-        </ListItem>
+        {/* Only allow this option for the author */}
+        { canEditPost() &&
+          <ListItem button onClick={() => props.onEditPost(props.post)}>
+            <ListItemIcon>
+              <EditIcon />
+            </ListItemIcon>
+            <ListItemText primary="Edit Post" />
+          </ListItem>
+        }
+        { !isAuthor() &&
+          <div>
+            <ListItem button onClick={() => props.onLike(props.id)}>
+              <ListItemIcon>
+                <ThumbUpIcon />
+              </ListItemIcon>
+              <ListItemText primary="Like" />
+            </ListItem>
+            <ListItem button onClick={() => props.onDislike(props.id)}>
+              <ListItemIcon>
+                <ThumbDownIcon />
+              </ListItemIcon>
+              <ListItemText primary="Dislike" />
+            </ListItem>
+          </div>
+        }
+        { canComment() &&
+          <ListItem button onClick={() => props.onAddComment(props.id)}>
+            <ListItemIcon>
+              <AddCommentIcon />
+            </ListItemIcon>
+            <ListItemText primary="Add Comment" />
+          </ListItem>
+        }
+        { canEditComment() &&
+          <ListItem button onClick={() => props.onEditComment(props.comment)}>
+            <ListItemIcon>
+              <EditIcon />
+            </ListItemIcon>
+            <ListItemText primary="Edit Comment" />
+          </ListItem>
+        }
+        { !isAuthor() &&
+          <ListItem button onClick={() => props.onFriendRequest(props.author)}>
+            <ListItemIcon>
+              <PersonAddIcon />
+            </ListItemIcon>
+            <ListItemText primary="Friend Request" />
+          </ListItem>
+        }
       </List>
       <Divider />
-      <List>
-        <ListItem button onClick={() => props.onReport(props.id)}>
-          <ListItemIcon>
-            <ReportIcon />
-          </ListItemIcon>
-          <ListItemText primary="Report" />
-        </ListItem>
-      </List>
+      { !isAuthor() &&
+        <List>
+          <ListItem button onClick={() => props.onReport(props.id)}>
+            <ListItemIcon>
+              <ReportIcon />
+            </ListItemIcon>
+            <ListItemText primary="Report" />
+          </ListItem>
+        </List>
+      }
     </div>
   );
 
@@ -121,6 +174,11 @@ export const ContextActionsMenu = (props) => {
 
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleEditComment = () => {
+    props.onEditComment(props.comment);
+    handleClose();
   };
 
   const handleEditPost = () => {
@@ -153,6 +211,42 @@ export const ContextActionsMenu = (props) => {
     handleClose();
   }
 
+  const canComment = () => {
+    let allowComment = false;
+    if (props.post) {
+      // We current only support comments on posts.
+      allowComment = true; 
+    }
+    return allowComment;
+  }
+
+  // Show the edit post option when the context menu is attached to
+  // a post and the user is the author.
+  const canEditComment = () => {
+    return isAuthor() && props.comment;
+  }
+
+  // Show the edit post option when the context menu is attached to
+  // a post and the user is the author.
+  const canEditPost = () => {
+    return isAuthor() && props.post;
+  }
+
+  // Checks if the current user is the owner of the post or comment.
+  const isAuthor = () => {
+    let author = false;
+
+    if (props.post && props.userId == props.post.author.id) {
+      author = true;
+    }
+
+    if (props.comment && props.userId == props.comment.author.id) {
+      author = true;
+    }
+
+    return author;
+  }
+
   return (
   <>
     <IconButton
@@ -168,7 +262,7 @@ export const ContextActionsMenu = (props) => {
       onClose={handleClose}
     >
       {/* Only allow this option for the author */}
-      { props.userId == props.post.author.id &&
+      { canEditPost() && 
         <MenuItem onClick={handleEditPost}>
           <ListItemIcon>
             <EditIcon />
@@ -176,36 +270,57 @@ export const ContextActionsMenu = (props) => {
           <ListItemText primary="Edit Post" />
         </MenuItem>
       }
-      <MenuItem onClick={handleLike}>
-        <ListItemIcon>
-          <ThumbUpIcon />
-        </ListItemIcon>
-        <ListItemText primary="Like" />
-      </MenuItem>
-      <MenuItem onClick={handleDislike}>
-        <ListItemIcon>
-          <ThumbDownIcon />
-        </ListItemIcon>
-        <ListItemText primary="Dislike" />
-      </MenuItem>
-      <MenuItem onClick={handleAddComment}>
-        <ListItemIcon>
-          <AddCommentIcon />
-        </ListItemIcon>
-        <ListItemText primary="Add Comment" />
-      </MenuItem>
-      <MenuItem onClick={handleFriendRequest}>
-        <ListItemIcon>
-          <PersonAddIcon />
-        </ListItemIcon>
-        <ListItemText primary="Friend Request" />
-      </MenuItem>
-      <MenuItem onClick={handleReport}>
-        <ListItemIcon>
-          <ReportIcon />
-        </ListItemIcon>
-        <ListItemText primary="Report" />
-      </MenuItem>
+      {/* Don't allow the author to like or dislike their own content */}
+      { !isAuthor() &&
+        <div>
+          <MenuItem onClick={handleLike}>
+            <ListItemIcon>
+              <ThumbUpIcon />
+            </ListItemIcon>
+            <ListItemText primary="Like" />
+          </MenuItem>
+          <MenuItem onClick={handleDislike}>
+            <ListItemIcon>
+              <ThumbDownIcon />
+            </ListItemIcon>
+            <ListItemText primary="Dislike" />
+          </MenuItem>
+        </div>
+      }
+      { canComment() && 
+        <MenuItem onClick={handleAddComment}>
+          <ListItemIcon>
+            <AddCommentIcon />
+          </ListItemIcon>
+          <ListItemText primary="Add Comment" />
+        </MenuItem>
+      }
+      { canEditComment() && 
+        <MenuItem onClick={handleEditComment}>
+          <ListItemIcon>
+            <EditIcon />
+          </ListItemIcon>
+          <ListItemText primary="Edit Comment" />
+        </MenuItem>
+      }
+      {/* User shouldn't be able to request themselves
+         as a friend or report there comments or posts. */}
+      { !isAuthor() &&
+        <div>
+          <MenuItem onClick={handleFriendRequest}>
+            <ListItemIcon>
+              <PersonAddIcon />
+            </ListItemIcon>
+            <ListItemText primary="Friend Request" />
+          </MenuItem>
+          <MenuItem onClick={handleReport}>
+            <ListItemIcon>
+              <ReportIcon />
+            </ListItemIcon>
+            <ListItemText primary="Report" />
+          </MenuItem>
+        </div>
+      }
     </Menu>
   </>
   );

--- a/client/src/views/post/Comment.js
+++ b/client/src/views/post/Comment.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useContext } from "react";
+import { UserContext } from 'data/UserStore';
 import Avatar from '@material-ui/core/Avatar';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
@@ -7,9 +8,54 @@ import Typography from '@material-ui/core/Typography';
 import Hidden from '@material-ui/core/Hidden';
 import { ContextActions } from 'views/ContextActions';
 import classes from './Comment.module.css';
+import { CommentForm } from 'views/post/CommentForm';
 
 
 export const Comment = (props) => {
+  const [state, dispatch] = useContext(UserContext);
+
+  const handleEditComment = (comment) => {
+    console.log(comment);
+    const { id, content } = { ...comment};
+    const commentData = { id, content };
+    dispatch({
+      type: 'editComment',
+      payload: <CommentForm {...commentData} /> 
+    });
+  };
+
+  const handleLike = (commentId) => {
+    dispatch({
+      type: 'likeComment',
+      payload: commentId 
+    });
+  };
+
+  const handleDislike = (commentId) => {
+    dispatch({
+      type: 'dislikeComment',
+      payload: commentId 
+    });
+  };
+
+  const handleFriendRequest = (author) => {
+    dispatch({
+      type: 'newFriendRequest',
+      payload: {
+        userId: state.user.id,
+        friendId: author.id
+      }
+    });
+  };
+
+  const handleReport = (commentId) => {
+    dispatch({
+      type: 'reportComment',
+      payload: commentId 
+    });
+  }
+
+
   return (
     <>
       <Card className={classes.root}>
@@ -21,7 +67,17 @@ export const Comment = (props) => {
             />
           }
           action={
-            <ContextActions />
+            <ContextActions
+              userId={state.user.id}
+              id={props.comment.id}
+              comment={props.comment}
+              author={props.comment.author}
+              onEditComment={(comment) => handleEditComment(comment)}
+              onLike={(commentId) => handleLike(commentId)}
+              onDislike={(commentId) => handleDislike(commentId)}
+              onFriendRequest={(author) => handleFriendRequest(author)}
+              onReport={(commentId) => handleReport(commentId)}
+            />
           }
           title={
             props.comment.author.username


### PR DESCRIPTION
…ir own posts or comments; nor can they request themself as a friend.  A user can edit their own post or comment, these options are found in the context menu.  Regarding a post that is not authored by the user, the user can add comment, like, dislike, request friend or report.  For a comment of another user, a user can like, dislike, request a friend or report.  Current ContextMenu has a bit of duplicated code, but I'm not planning to do anything about it.  I'm still not sure if the mobile and desktop need different versions of the same options.