### PR TITLE
Moved the check for a user before trying to report a post or comment.…

### DIFF
--- a/api/routes/comments.reports.route.js
+++ b/api/routes/comments.reports.route.js
@@ -25,24 +25,27 @@ const CommentServices = require('../services/CommentServices');
  * CREATE: add a new comment report.
  * 
  * @author Christopher Thacker
+ * @author Michael McCulloch
  * @since 1.0.0
  */
 router.put('/:id', async (req, res) => {
-    try {
-        if (req.session.user) {
-            const user = req.session.user;
-            const isReported = await CommentServices.addReport(req.params.id, user.id);
+    // Only authenticated users should able to add a comment.
+    if (req.session.user) {
+        try {
+                const user = req.session.user;
+                const isReported = await CommentServices.addReport(req.params.id, user.id);
 
-            if (isReported) {
-                return res.status(200).json({comment: isReported});
-            }
-            return res.status(403).json({error: 'Comment was not reported'});
+                if (isReported) {
+                    return res.status(200).json({comment: isReported});
+                }
+                return res.status(403).json({error: 'Comment was not reported'});
+        } catch (error) {
+            console.log(error.message);
+            return res.status(500).send(error);
         }
-        return res.status(401).json({error: 'User not logged in'});
-    } catch (error) {
-        console.log(error.message);
-        return res.status(500).send(error);
     }
+
+    return res.status(401).json({error: 'User not logged in'});
 });
 
 /**

--- a/api/routes/posts.reports.route.js
+++ b/api/routes/posts.reports.route.js
@@ -25,11 +25,13 @@ const PostServices = require('../services/PostServices');
  * CREATE: add a new post report.
  * 
  * @author Christopher Thacker
+ * @author Michael McCulloch
  * @since 1.0.0
  */
 router.put('/:id', async (req, res) => {
-    try {
-        if (req.session.user) {
+
+    if (req.session.user) {
+        try {
             const user = req.session.user;
             const isReported = await PostServices.addReport(req.params.id, user.id);
 
@@ -37,12 +39,13 @@ router.put('/:id', async (req, res) => {
                 return res.status(200).json({post: isReported});
             }
             return res.status(403).json({error: 'Post was not reported'});
+        } catch (error) {
+            console.log(error.message);
+            return res.status(500).send(error);
         }
-        return res.status(401).json({error: 'User not logged in'});
-    } catch (error) {
-        console.log(error.message);
-        return res.status(500).send(error);
     }
+
+    return res.status(401).json({error: 'User not logged in'});
 });
 
 /**


### PR DESCRIPTION
…  The reason for the change—is that if a user for some reason doesn't have a userId in the session; then a report is created with a new _id.